### PR TITLE
Allow request for multiple comma-separated presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ Please ensure that the documentation source is reliable and actively maintained.
 
 ## Feature requests
 
-- [ ] Combine multiple documentation sources (e.g., https://llmctx.com/svelte,sveltekit)
+- [x] Combine multiple documentation sources (e.g., https://llmctx.com/svelte,sveltekit)
 - [ ] Create a "stack" of frequently used frameworks and libraries
 - [ ] Implement a checkbox UI for selecting presets and generate custom URLs based on selected documentation


### PR DESCRIPTION
These changes allow for a request to specify multiple presets, separated by a comma. (e.g., https://llmctx.com/svelte,sveltekit)