### PR TITLE
fix broken runes syntax

### DIFF
--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -1,4 +1,5 @@
 import type { GlobPattern } from 'glob'
+import type { MinimizeOptions } from './fetchMarkdown'
 
 export type PresetConfig = {
 	/** The pretty title of the preset */
@@ -11,6 +12,8 @@ export type PresetConfig = {
 	glob: GlobPattern[]
 	/** Optional prompt to provide additional context or instructions to language models */
 	prompt?: string
+	/** Minimization options for the content */
+	minimize?: MinimizeOptions
 }
 
 export const presets: Record<string, PresetConfig> = {
@@ -19,13 +22,23 @@ export const presets: Record<string, PresetConfig> = {
 		owner: 'sveltejs',
 		repo: 'svelte',
 		glob: ['**/documentation/docs/**/*.md'],
-		prompt: 'Always use Svelte 5 runes. Runes do not need to be imported, they are globals.'
+		prompt: 'Always use Svelte 5 runes. Runes do not need to be imported, they are globals.',
+		minimize: {
+			removeCodeBlocks: false,
+			removeSquareBrackets: false,
+			removeParentheses: false
+		}
 	},
 	sveltekit: {
 		title: 'SvelteKit',
 		owner: 'sveltejs',
 		repo: 'kit',
-		glob: ['**/documentation/docs/**/*.md']
+		glob: ['**/documentation/docs/**/*.md'],
+		minimize: {
+			removeCodeBlocks: false,
+			removeSquareBrackets: false,
+			removeParentheses: false
+		}
 	},
 	'supabase-js': {
 		title: 'Supabase',


### PR DESCRIPTION
The code minification is too aggressive, it creates broken syntax. For example, `$state()` and `$state(42)` is turned into `$state` so the LLM writes code incorrectly. You can see this by searching for $state in https://llmctx.com/svelte

This is a small patch to fix the biggest problem, I also reintroduced the code examples into the Svelte/Kit presets because without any code examples the LLM use becomes very limited as it's mainly code examples you want to emulate.