### PR TITLE
Add svelte presets

### DIFF
--- a/src/lib/fetchMarkdown.ts
+++ b/src/lib/fetchMarkdown.ts
@@ -132,27 +132,27 @@ function minimizeContent(content: string, options?: Partial<MinimizeOptions>): s
 	let minimized = content
 
 	if (settings.normalizeWhitespace) {
-		console.log('Normalizing whitespace')
+		//console.log('Normalizing whitespace')
 		minimized = minimized.replace(/\s+/g, ' ')
 	}
 
 	if (settings.removeCodeBlocks) {
-		console.log('Removing code blocks')
+		//console.log('Removing code blocks')
 		minimized = minimized.replace(/```[\s\S]*?```/g, '')
 	}
 
 	if (settings.removeSquareBrackets) {
-		console.log('Removing square brackets')
+		//console.log('Removing square brackets')
 		minimized = minimized.replace(/\[.*?\]/g, '')
 	}
 
 	if (settings.removeParentheses) {
-		console.log('Removing parentheses')
+		//console.log('Removing parentheses')
 		minimized = minimized.replace(/\(.*?\)/g, '')
 	}
 
 	if (settings.trim) {
-		console.log('Trimming whitespace')
+		//console.log('Trimming whitespace')
 		minimized = minimized.trim()
 	}
 

--- a/src/lib/fetchMarkdown.ts
+++ b/src/lib/fetchMarkdown.ts
@@ -15,11 +15,23 @@ export async function fetchAndProcessMarkdown(preset: PresetConfig): Promise<str
 	return files.join(' ')
 }
 
+function shouldIncludeFile(filename: string, glob: string[], ignore: string[] = []): boolean {
+	// First check if the file should be ignored
+	const shouldIgnore = ignore.some((pattern) => minimatch(filename, pattern))
+	if (shouldIgnore) {
+		return false
+	}
+
+	// Then check if the file matches include patterns
+	return glob.some((pattern) => minimatch(filename, pattern))
+}
+
 // Fetch markdown files using GitHub's tarball API
 async function fetchMarkdownFiles({
 	owner,
 	repo,
 	glob,
+	ignore = [],
 	minimize = undefined
 }: PresetConfig): Promise<string[]> {
 	// Construct the tarball URL
@@ -50,16 +62,13 @@ async function fetchMarkdownFiles({
 	// Process each file in the tarball
 	extractStream.on('entry', (header, stream, next) => {
 		processedFiles++
-		const isAllowed = glob.some((pattern) => {
-			const isNegated = pattern.startsWith('!')
-			const matchPattern = isNegated ? pattern.slice(1) : pattern
-			const matches = minimatch(header.name, matchPattern)
-			return isNegated ? !matches : matches
-		})
+		const isAllowed = shouldIncludeFile(header.name, glob, ignore)
 
 		if (dev) {
 			if (isAllowed) {
 				console.info(`Allowed file: ${header.name}`)
+			} else if (ignore?.some((pattern) => minimatch(header.name, pattern))) {
+				console.info(`Ignored file: ${header.name}`)
 			}
 		}
 
@@ -100,12 +109,12 @@ async function fetchMarkdownFiles({
 	return contents
 }
 
-interface MinimizeOptions {
-	normalizeWhitespace: boolean
-	removeCodeBlocks: boolean
-	removeSquareBrackets: boolean
-	removeParentheses: boolean
-	trim: boolean
+export interface MinimizeOptions {
+	normalizeWhitespace?: boolean
+	removeCodeBlocks?: boolean
+	removeSquareBrackets?: boolean
+	removeParentheses?: boolean
+	trim?: boolean
 }
 
 const defaultOptions: MinimizeOptions = {
@@ -150,7 +159,7 @@ function minimizeContent(content: string, options?: Partial<MinimizeOptions>): s
 	if (dev) {
 		console.log(`Original content length: ${content.length}`)
 		console.log(`Minimized content length: ${minimized.length}`)
-		console.log('Applied minimizations:', JSON.stringify(settings, null, 2))
+		console.log('Applied minimizations:', Object.keys(settings).join(', '))
 	}
 
 	return minimized

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -22,26 +22,28 @@ export const presets: Record<string, PresetConfig> = {
 	svelte: {
 		title: 'Svelte',
 		owner: 'sveltejs',
-		repo: 'svelte',
-		glob: ['**/documentation/docs/**/*.md'],
-		ignore: ['**/documentation/docs/99-legacy/**/*.md'],
+		repo: 'svelte.dev',
+		glob: ['**/apps/svelte.dev/content/docs/svelte/**/*.md'],
+		ignore: ['**/apps/svelte.dev/content/docs/svelte/99-legacy/**/*.md'],
 		prompt: 'Always use Svelte 5 runes. Runes do not need to be imported, they are globals.',
 		minimize: {
 			removeCodeBlocks: false,
 			removeSquareBrackets: false,
 			removeParentheses: false,
-			normalizeWhitespace: false
+			normalizeWhitespace: true
 		}
 	},
 	sveltekit: {
 		title: 'SvelteKit',
 		owner: 'sveltejs',
-		repo: 'kit',
-		glob: ['**/documentation/docs/**/*.md'],
+		repo: 'svelte.dev',
+		glob: ['**/apps/svelte.dev/content/docs/kit/**/*.md'],
+		ignore: [],
 		minimize: {
 			removeCodeBlocks: false,
 			removeSquareBrackets: false,
-			removeParentheses: false
+			removeParentheses: false,
+			normalizeWhitespace: true
 		}
 	},
 	'supabase-js': {

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -8,8 +8,10 @@ export type PresetConfig = {
 	owner: string
 	/** The name of the GitHub repository */
 	repo: string
-	/** List of glob patterns for including and excluding files */
+	/** List of glob patterns for including files */
 	glob: GlobPattern[]
+	/** List of glob patterns for excluding files */
+	ignore?: GlobPattern[]
 	/** Optional prompt to provide additional context or instructions to language models */
 	prompt?: string
 	/** Minimization options for the content */
@@ -22,11 +24,13 @@ export const presets: Record<string, PresetConfig> = {
 		owner: 'sveltejs',
 		repo: 'svelte',
 		glob: ['**/documentation/docs/**/*.md'],
+		ignore: ['**/documentation/docs/99-legacy/**/*.md'],
 		prompt: 'Always use Svelte 5 runes. Runes do not need to be imported, they are globals.',
 		minimize: {
 			removeCodeBlocks: false,
 			removeSquareBrackets: false,
-			removeParentheses: false
+			removeParentheses: false,
+			normalizeWhitespace: false
 		}
 	},
 	sveltekit: {

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -46,6 +46,19 @@ export const presets: Record<string, PresetConfig> = {
 			normalizeWhitespace: true
 		}
 	},
+	'svelte-cli': {
+		title: 'Svelte CLI (npx sv)',
+		owner: 'sveltejs',
+		repo: 'svelte.dev',
+		glob: ['**/apps/svelte.dev/content/docs/cli/**/*.md'],
+		ignore: [],
+		minimize: {
+			removeCodeBlocks: false,
+			removeSquareBrackets: false,
+			removeParentheses: false,
+			normalizeWhitespace: false
+		}
+	},
 	'supabase-js': {
 		title: 'Supabase',
 		owner: 'supabase',

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -67,7 +67,7 @@ export const presets: Record<string, PresetConfig> = {
 		glob: ['**/apps/svelte.dev/content/docs/kit/**/*.md'],
 		ignore: [],
 		minimize: {
-			removeCodeBlocks: false,
+			removeCodeBlocks: true,
 			removeSquareBrackets: false,
 			removeParentheses: false,
 			normalizeWhitespace: true

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -33,8 +33,35 @@ export const presets: Record<string, PresetConfig> = {
 			normalizeWhitespace: true
 		}
 	},
+	'svelte-small': {
+		title: 'Svelte (Small)',
+		owner: 'sveltejs',
+		repo: 'svelte.dev',
+		glob: ['**/apps/svelte.dev/content/docs/svelte/**/*.md'],
+		ignore: ['**/apps/svelte.dev/content/docs/svelte/99-legacy/**/*.md'],
+		prompt: 'Always use Svelte 5 runes. Runes do not need to be imported, they are globals.',
+		minimize: {
+			removeCodeBlocks: true,
+			removeSquareBrackets: false,
+			removeParentheses: false,
+			normalizeWhitespace: true
+		}
+	},
 	sveltekit: {
 		title: 'SvelteKit',
+		owner: 'sveltejs',
+		repo: 'svelte.dev',
+		glob: ['**/apps/svelte.dev/content/docs/kit/**/*.md'],
+		ignore: [],
+		minimize: {
+			removeCodeBlocks: false,
+			removeSquareBrackets: false,
+			removeParentheses: false,
+			normalizeWhitespace: true
+		}
+	},
+	'sveltekit-small': {
+		title: 'SvelteKit (Small)',
 		owner: 'sveltejs',
 		repo: 'svelte.dev',
 		glob: ['**/apps/svelte.dev/content/docs/kit/**/*.md'],

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -34,7 +34,10 @@
 
 		<p>
 			llmctx.com transforms docs into LLM-friendly formats. Pick a preset, get AI-ready context.
-			Perfect for coding with AI assistants like Cursor or Zed.
+			Perfect for coding with AI assistants like Cursor or Zed, or uploading to Claude Projects.
+		</p>
+		<p>
+			<em>"Small" versions have reduced file size, but some documentation content is omitted.</em>
 		</p>
 	</article>
 


### PR DESCRIPTION
* Adds `ignore` pattern config
* Use [the omnisite](https://github.com/sveltejs/svelte.dev/tree/main/apps/svelte.dev/content/docs) as docs source. This is the most up to date source and the same as the svelte.dev site.
* Remove legacy Svelte 4 docs from Svelte preset.
* Add "small" preset for Svelte & Kit. This corresponds to what we had before https://github.com/didier/llmctx/pull/4 ie we omit the code samples but keep the rest of the docs. 
* Add separate Svelte CLI preset, since the omnisite offers one. (Although it's pretty small for now and could probably be in the normal Svelte preset?

After this PR I plan to dive down into the docs themselves and make a nicer "Small" preset that includes code samples but omits repetitive code (for example, we might fully omit the tutorial part of the Kit docs and just rely on the normal docs).